### PR TITLE
Interior mutability for ArcObservable

### DIFF
--- a/src/arc_observable.rs
+++ b/src/arc_observable.rs
@@ -38,10 +38,7 @@ where
         self.value.clone()
     }
 
-    // We technically don't need a mutable reference to self here,
-    // but we want only owners of the variable to be able to set new values.
-    // This also matches the API of the "normal" Observable.
-    pub async fn set(&mut self, value: T) -> Result<T> {
+    pub async fn set(&self, value: T) -> Result<T> {
         let mut hasher = DefaultHasher::new();
         value.hash(&mut hasher);
         let new_value_hash = hasher.finish();

--- a/tests/observables.rs
+++ b/tests/observables.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[tokio::test]
     async fn arc_observable_subscriber_receives_data_on_change() {
-        let mut observable = ArcObservable::new(TEST_DATA_INITIAL, TEST_EVENT_NAME);
+        let observable = ArcObservable::new(TEST_DATA_INITIAL, TEST_EVENT_NAME);
 
         let count = Arc::new(AtomicU8::new(0));
 


### PR DESCRIPTION
Do not require a mutable reference for `ArcObservable`'s `set()`, as it makes use of interior mutability internally. This was just done artificial to match `Observable`'s `set()`. It limited the usage of `ArcObservable` for no reason.