### PR TITLE
refactor(event_repeater): use error_unreachable! where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "lum_log"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2aa8a9e10a382f3c41d280ef3a47277444ac311cc77ac99b8ba14c40d667ec"
+checksum = "581e3430d4df38dff24088add5f29d272160fb0f65c44098822d9978133b91f3"
 dependencies = [
  "lum_libs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ lto = false
 [dependencies]
 lum_boxtypes = "0.2.1"
 lum_libs = { version = "0.2.6", features = ["fern", "humantime", "log", "serde", "tokio", "uuid"] }
-lum_log = "0.2.6"
+lum_log = "0.2.7"
 thiserror = "2.0.12"

--- a/src/event_repeater.rs
+++ b/src/event_repeater.rs
@@ -2,7 +2,7 @@ use lum_libs::{
     tokio::{self, sync::Mutex, task::JoinHandle},
     uuid::Uuid,
 };
-use lum_log::error;
+use lum_log::{error, error_unreachable};
 use std::{
     collections::HashMap,
     sync::{Arc, OnceLock, Weak},
@@ -67,12 +67,8 @@ impl<T: Clone + Send + 'static> EventRepeater<T> {
 
         let result = arc.weak.set(weak);
         if result.is_err() {
-            error!(
+            error_unreachable!(
                 "Failed to set EventRepeater {}'s Weak self-reference because it was already set. This should never happen. Panicking to prevent further undefined behavior.",
-                arc.event.name
-            );
-            unreachable!(
-                "Unable to set EventRepeater {}'s Weak self-reference because it was already set.",
                 arc.event.name
             );
         }
@@ -99,13 +95,10 @@ impl<T: Clone + Send + 'static> EventRepeater<T> {
         let arc = match weak.upgrade() {
             Some(arc) => arc,
             None => {
-                error!(
+                error_unreachable!(
                     "EventRepeater {}'s Weak self-reference could not be upgraded to Arc while attaching event {}. This should never happen. Panicking to prevent further undefined behavior.",
-                    self.event.name, event.name
-                );
-                unreachable!(
-                    "EventRepeater {}'s Weak self-reference could not be upgraded to Arc while attaching event {}.",
-                    self.event.name, event.name
+                    self.event.name,
+                    event.name
                 );
             }
         };


### PR DESCRIPTION
- update `lum_log` to **0.2.7**
- use `error_unreachable!` where possible